### PR TITLE
Streaming work

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+Release 0.1.1 (pending)
+==========================
+
+- Use atomics for ring buffer implementation
+- Use Format string constants for stream types
+
 Release 0.1.0 (2016-09-01)
 ==========================
 

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,7 @@
 Release 0.1.1 (pending)
 ==========================
 
+- Support native AIRSPY_SAMPLE_INT16_IQ format
 - Use atomics for ring buffer implementation
 - Use Format string constants for stream types
 

--- a/SoapyAirspy.hpp
+++ b/SoapyAirspy.hpp
@@ -229,7 +229,7 @@ public:
     size_t	_buf_head;
     size_t	_buf_tail;
     std::atomic<size_t>	_buf_count;
-    float *_currentBuff;
+    char *_currentBuff;
     std::atomic<bool> _overflowEvent;
     size_t bufferedElems;
     size_t _currentHandle;

--- a/SoapyAirspy.hpp
+++ b/SoapyAirspy.hpp
@@ -38,8 +38,8 @@
 
 #include <libairspy/airspy.h>
 
-#define DEFAULT_BUFFER_LENGTH 2048
-#define DEFAULT_NUM_BUFFERS 6
+#define DEFAULT_BUFFER_BYTES 262144
+#define DEFAULT_NUM_BUFFERS 8
 #define MAX_DEVICES 32
 
 class SoapyAirspy: public SoapySDR::Device

--- a/SoapyAirspy.hpp
+++ b/SoapyAirspy.hpp
@@ -34,6 +34,7 @@
 #include <string>
 #include <cstring>
 #include <algorithm>
+#include <atomic>
 
 #include <libairspy/airspy.h>
 
@@ -228,9 +229,9 @@ public:
     std::vector<std::vector<float> > _buffs;
     size_t	_buf_head;
     size_t	_buf_tail;
-    size_t	_buf_count;
+    std::atomic<size_t>	_buf_count;
     float *_currentBuff;
-    bool _overflowEvent;
+    std::atomic<bool> _overflowEvent;
     size_t bufferedElems;
     size_t _currentHandle;
     bool resetBuffer;

--- a/SoapyAirspy.hpp
+++ b/SoapyAirspy.hpp
@@ -215,8 +215,7 @@ private:
     size_t numBuffers;
     bool agcMode, streamActive, rfBias;
     std::atomic_bool sampleRateChanged;
-    int elementsPerSample;
-    airspy_sample_type asFormat;
+    int bytesPerSample;
     uint8_t lnaGain, mixerGain, vgaGain;
     
 public:
@@ -226,7 +225,7 @@ public:
     std::mutex _buf_mutex;
     std::condition_variable _buf_cond;
 
-    std::vector<std::vector<float> > _buffs;
+    std::vector<std::vector<char> > _buffs;
     size_t	_buf_head;
     size_t	_buf_tail;
     std::atomic<size_t>	_buf_count;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -103,7 +103,13 @@ int SoapyAirspy::rx_callback(airspy_transfer *t)
 
     //increment the tail pointer
     _buf_tail = (_buf_tail + 1) % numBuffers;
-    _buf_count++;
+
+    //increment buffers available under lock
+    //to avoid race in acquireReadBuffer wait
+    {
+        std::lock_guard<std::mutex> lock(_buf_mutex);
+        _buf_count++;
+    }
 
     //notify readStream()
     _buf_cond.notify_one();
@@ -295,7 +301,7 @@ int SoapyAirspy::acquireReadBuffer(
     if (_buf_count == 0)
     {
         std::unique_lock <std::mutex> lock(_buf_mutex);
-        _buf_cond.wait_for(lock, std::chrono::microseconds(timeoutUs));
+        _buf_cond.wait_for(lock, std::chrono::microseconds(timeoutUs), [this]{return _buf_count != 0;});
         if (_buf_count == 0) return SOAPY_SDR_TIMEOUT;
     }
 

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -151,7 +151,11 @@ SoapySDR::Stream *SoapyAirspy::setupStream(
     sampleRateChanged.store(true);
 
     bytesPerSample = SoapySDR::formatToSize(format);
-    bufferLength = DEFAULT_BUFFER_LENGTH*bytesPerSample;
+
+    //We get this many complex samples over the bus.
+    //Its the same for both complex float and int16.
+    //TODO adjust when packing is enabled
+    bufferLength = DEFAULT_BUFFER_BYTES/4;
 
     //clear async fifo counts
     _buf_tail = 0;

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -24,6 +24,7 @@
 
 #include "SoapyAirspy.hpp"
 #include <SoapySDR/Logger.hpp>
+#include <SoapySDR/Formats.hpp>
 #include <algorithm> //min
 #include <climits> //SHRT_MAX
 #include <cstring> // memcpy
@@ -33,15 +34,15 @@ std::vector<std::string> SoapyAirspy::getStreamFormats(const int direction, cons
     std::vector<std::string> formats;
 
     // formats.push_back("CS8");
-    formats.push_back("CS16");
-    formats.push_back("CF32");
+    formats.push_back(SOAPY_SDR_CS16);
+    formats.push_back(SOAPY_SDR_CF32);
 
     return formats;
 }
 
 std::string SoapyAirspy::getNativeStreamFormat(const int direction, const size_t channel, double &fullScale) const {
      fullScale = 65536;
-     return "CS16";
+     return SOAPY_SDR_CS16;
 }
 
 SoapySDR::ArgInfoList SoapyAirspy::getStreamArgsInfo(const int direction, const size_t channel) const {
@@ -130,10 +131,10 @@ SoapySDR::Stream *SoapyAirspy::setupStream(
     asFormat = AIRSPY_SAMPLE_INT16_IQ;
 
     //check the format
-    if (format == "CF32") {
+    if (format == SOAPY_SDR_CF32) {
         SoapySDR_log(SOAPY_SDR_INFO, "Using format CF32.");
         asFormat = AIRSPY_SAMPLE_FLOAT32_IQ;
-    } else if (format == "CS16") {
+    } else if (format == SOAPY_SDR_CS16) {
         SoapySDR_log(SOAPY_SDR_INFO, "Using format CS16.");
         asFormat = AIRSPY_SAMPLE_INT16_IQ;
     } else {

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -164,8 +164,8 @@ SoapySDR::Stream *SoapyAirspy::setupStream(
 
     //allocate buffers
     _buffs.resize(numBuffers);
-    for (auto &buff : _buffs) buff.reserve(bufferLength);
-    for (auto &buff : _buffs) buff.resize(bufferLength);
+    for (auto &buff : _buffs) buff.reserve(bufferLength*bytesPerSample);
+    for (auto &buff : _buffs) buff.resize(bufferLength*bytesPerSample);
 
     return (SoapySDR::Stream *) this;
 }
@@ -177,7 +177,7 @@ void SoapyAirspy::closeStream(SoapySDR::Stream *stream)
 
 size_t SoapyAirspy::getStreamMTU(SoapySDR::Stream *stream) const
 {
-    return bufferLength / bytesPerSample;
+    return bufferLength;
 }
 
 int SoapyAirspy::activateStream(


### PR DESCRIPTION
- Resolves https://github.com/pothosware/SoapyAirspy/issues/6
- Use larger transfers that match libairspy settings
- Reduce time spent in locks when not needed
