### PR TITLE
Fix cmake and compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,23 +2,23 @@
 # Build Soapy SDR support module for Airspy Devices
 ###################################################
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(SoapyAirspy CXX)
 
 find_package(SoapySDR "0.4.0" NO_MODULE REQUIRED)
-if (NOT SoapySDR_FOUND)
+if(NOT SoapySDR_FOUND)
     message(FATAL_ERROR "Soapy SDR development files not found...")
-endif ()
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
-find_package(LibAIRSPY)
+find_package(LibAIRSPY REQUIRED)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${LIBAIRSPY_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${LibAIRSPY_INCLUDE_DIRS})
 
 #enable c++11 features
-if(CMAKE_COMPILER_IS_GNUCXX)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     #C++11 is a required language feature for this project
     include(CheckCXXCompilerFlag)
     CHECK_CXX_COMPILER_FLAG("-std=c++11" HAS_STD_CXX11)
@@ -30,8 +30,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     #Thread support enabled (not the same as -lpthread)
     list(APPEND AIRSPY_LIBS -pthread)
     #disable warnings for unused parameters
-    add_definitions(-Wno-unused-parameter)
-endif(CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+endif()
 
 if (APPLE)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wc++11-extensions")
@@ -45,7 +45,7 @@ endif(APPLE)
 #SET (AIRSPY_LIBS ${COREFOUNDATION_LIBRARY} ${AIRSPY_LIBS} )
 # ENDIF (APPLE)
 
-list(APPEND AIRSPY_LIBS ${LIBAIRSPY_LIBRARIES})
+list(APPEND AIRSPY_LIBS ${LibAIRSPY_LIBRARIES})
 
 SOAPY_SDR_MODULE_UTIL(
     TARGET airspySupport

--- a/FindLibAIRSPY.cmake
+++ b/FindLibAIRSPY.cmake
@@ -1,24 +1,44 @@
-INCLUDE(FindPkgConfig)
-PKG_CHECK_MODULES(PC_LIBAIRSPY libairspy)
+# - Try to find LibAIRSPY
+# Once done this will define
+#
+#  LibAIRSPY_FOUND - System has libairspy
+#  LibAIRSPY_INCLUDE_DIRS - The libairspy include directories
+#  LibAIRSPY_LIBRARIES - The libraries needed to use libairspy
+#  LibAIRSPY_DEFINITIONS - Compiler switches required for using libairspy
+#  LibAIRSPY_VERSION - The librtlsdr version
+#
 
-FIND_PATH(
-    LIBAIRSPY_INCLUDE_DIRS
+find_package(PkgConfig)
+pkg_check_modules(PC_LibAIRSPY libairspy)
+set(LibAIRSPY_DEFINITIONS ${PC_LibAIRSPY_CFLAGS_OTHER})
+
+find_path(
+    LibAIRSPY_INCLUDE_DIRS
     NAMES libairspy/airspy.h
-    HINTS $ENV{LIBAIRSPY_DIR}/include
-        ${PC_LIBAIRSPY_INCLUDEDIR}
+    HINTS $ENV{LibAIRSPY_DIR}/include
+        ${PC_LibAIRSPY_INCLUDEDIR}
     PATHS /usr/local/include
           /usr/include
 )
 
-FIND_LIBRARY(
-    LIBAIRSPY_LIBRARIES
+find_library(
+    LibAIRSPY_LIBRARIES
     NAMES airspy
-    HINTS $ENV{LIBAIRSPY_DIR}/lib
-        ${PC_LIBAIRSPY_LIBDIR}
+    HINTS $ENV{LibAIRSPY_DIR}/lib
+        ${PC_LibAIRSPY_LIBDIR}
     PATHS /usr/local/lib
           /usr/lib
 )
 
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBAIRSPY DEFAULT_MSG LIBAIRSPY_LIBRARIES LIBAIRSPY_INCLUDE_DIRS)
-MARK_AS_ADVANCED(LIBAIRSPY_LIBRARIES LIBAIRSPY_INCLUDE_DIRS)
+set(LibAIRSPY_VERSION ${PC_LibAIRSPY_VERSION})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LibAIRSPY_FOUND to TRUE
+# if all listed variables are TRUE
+# Note that `FOUND_VAR LibAIRSPY_FOUND` is needed for cmake 3.2 and older.
+find_package_handle_standard_args(LibAIRSPY
+                                  FOUND_VAR LibAIRSPY_FOUND
+                                  REQUIRED_VARS LibAIRSPY_LIBRARIES LibAIRSPY_INCLUDE_DIRS
+                                  VERSION_VAR LibAIRSPY_VERSION)
+
+mark_as_advanced(LibAIRSPY_LIBRARIES LibAIRSPY_INCLUDE_DIRS)


### PR DESCRIPTION
This fixes the cmake warning about mismatched case in package search, proper case should be `LibAIRSPY`.

```
CMake Warning (dev) at FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (LibAIRSPY).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  FindLibAIRSPY.cmake:1 (INCLUDE)
  CMakeLists.txt:16 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Also uses `REQUIRED` on `find_package(LibAIRSPY)` to get explicit error messages instead of failing implicitly later on.

```
-- Checking for module 'libairspy'
--   No package 'libairspy' found
CMake Error at FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find LibAIRSPY (missing: LibAIRSPY_LIBRARIES
  LibAIRSPY_INCLUDE_DIRS)
```

(Note the mention of `LibAIRSPY_LIBRARIES` and `LibAIRSPY_INCLUDE_DIRS`, case does matter for e.g. build scripts.)

Adds Clang compatibility for compiler options. Bumps to a minimum of cmake 2.8.12 (Oct 2013) so we can use
`add_compile_options` to proper order `-Wall -Wextra` vs `-Wno-unused-parameter` which `add_definitions` won't do.
This gets rid of all the `warning: unused parameter 'foo' [-Wunused-parameter]`
